### PR TITLE
`fsPath` replace `path`  [fixed prettier on windows]

### DIFF
--- a/src/prettyhtmlEditProvider.ts
+++ b/src/prettyhtmlEditProvider.ts
@@ -22,7 +22,7 @@ async function format(
   options: { [index: string]: any },
   prettyhtmlOptions: { [index: string]: any }
 ): Promise<string> {
-  const localPrettierOptions = await resolveConfig(uri.path);
+  const localPrettierOptions = await resolveConfig(uri.fsPath);
 
   return await prettyhtml(text, {
     useTabs: prettyhtmlOptions.useTabs,


### PR DESCRIPTION
using `path`  on  windows bash cannot resolve the config of prettier